### PR TITLE
タグ選択モーダルを追加

### DIFF
--- a/components/commons/BaseTag.vue
+++ b/components/commons/BaseTag.vue
@@ -1,6 +1,16 @@
 <template>
   <div
-    class="px-4 py-0.5 mx-3 bg-white rounded-lg border border-gray-500 w-auto"
+    class="
+      px-4
+      py-0.5
+      mx-3
+      bg-white
+      rounded-lg
+      border border-gray-500
+      w-auto
+      cursor-pointer
+    "
+    :class="{ 'bg-slate-400': selected }"
   >
     {{ text }}
   </div>
@@ -13,5 +23,8 @@ import { Component, Prop, Vue } from 'nuxt-property-decorator'
 export default class BaseTag extends Vue {
   @Prop({ type: String, required: true, default: '' })
   text!: string
+
+  @Prop({ type: Boolean, required: false, default: false })
+  selected!: boolean
 }
 </script>

--- a/components/commons/Modal.vue
+++ b/components/commons/Modal.vue
@@ -1,0 +1,41 @@
+<template>
+  <div
+    v-if="modalInner"
+    class="
+      fixed
+      top-0
+      left-0
+      w-full
+      h-full
+      flex
+      justify-center
+      items-center
+      backdrop-blur-md
+    "
+    @click.self="close"
+  >
+    <div :is="modalInner" @close="close"></div>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { modalStore } from '~/store'
+import TagSelector from '@/components/works/TagSelector.vue'
+
+@Component({
+  components: { TagSelector }
+})
+export default class Modal extends Vue {
+  get modalInner() {
+    console.debug('modalInner')
+    return modalStore.getComponent === null
+      ? undefined
+      : modalStore.getComponent
+  }
+
+  public close() {
+    console.debug('close')
+    modalStore.close()
+  }
+}
+</script>

--- a/components/works/TagSelector.vue
+++ b/components/works/TagSelector.vue
@@ -9,6 +9,7 @@
       mx-auto
       bg-white
       flex flex-col
+      gap-y-3
     "
   >
     <div class="w-full flex flex-row justify-end">
@@ -18,13 +19,13 @@
         @click="$emit('close')"
       />
     </div>
-    <div class="w-full flex flex-row">
-      <div v-for="tag in tags" :key="tag">
-        <BaseTag :text="tag"></BaseTag>
+    <div class="w-full flex flex-row flex-wrap gap-y-3">
+      <div v-for="tag in tags" :key="tag.id" @click="selectTag(tag)">
+        <BaseTag :text="tag.name" :selected="isSelected(tag)"></BaseTag>
       </div>
     </div>
     <div class="w-full flex flex-row justify-end">
-      <BaseButton title="完了"></BaseButton>
+      <BaseButton title="完了" @click="close"></BaseButton>
     </div>
   </div>
 </template>
@@ -33,16 +34,45 @@
 import { Component, Vue } from 'nuxt-property-decorator'
 import BaseTag from '../commons/BaseTag.vue'
 import BaseButton from '../commons/BaseButton.vue'
+import { modalStore, tagStore, workFilterStore } from '~/store'
+import { Tag } from '~/types'
 
+/**
+ * Workの絞り込み条件を保持するStore
+ */
 @Component({
   components: {
     BaseTag,
     BaseButton
   }
 })
-export default class TagSelector extends Vue {
+export default class WorkFilter extends Vue {
   get tags() {
-    return ['hoge', 'fuga']
+    return tagStore.getTags
+  }
+
+  get selectedTags() {
+    const tags = tagStore.getTags
+    const selectedTags = workFilterStore.getFilterTags
+    return tags.filter((t) => selectedTags.some((st) => st.id === t.id))
+  }
+
+  isSelected(tag: Tag) {
+    return workFilterStore.getFilterTags.some((t) => t.id === tag.id)
+  }
+
+  async created() {
+    // タグをサーバーから取得し
+    await tagStore.fetchTags()
+  }
+
+  selectTag(tag: Tag) {
+    if (!this.isSelected(tag)) workFilterStore.addFilterTag(tag)
+    else workFilterStore.deleteFilterTag(tag)
+  }
+
+  close() {
+    modalStore.close()
   }
 }
 </script>

--- a/components/works/TagSelector.vue
+++ b/components/works/TagSelector.vue
@@ -1,0 +1,48 @@
+<template>
+  <div
+    class="
+      border-2 border-black
+      rounded-3xl
+      px-10
+      py-5
+      w-[45rem]
+      mx-auto
+      bg-white
+      flex flex-col
+    "
+  >
+    <div class="w-full flex flex-row justify-end">
+      <font-awesome-icon
+        class="w-7 cursor-pointer"
+        :icon="['fas', 'xmark']"
+        @click="$emit('close')"
+      />
+    </div>
+    <div class="w-full flex flex-row">
+      <div v-for="tag in tags" :key="tag">
+        <BaseTag :text="tag"></BaseTag>
+      </div>
+    </div>
+    <div class="w-full flex flex-row justify-end">
+      <BaseButton title="完了"></BaseButton>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import BaseTag from '../commons/BaseTag.vue'
+import BaseButton from '../commons/BaseButton.vue'
+
+@Component({
+  components: {
+    BaseTag,
+    BaseButton
+  }
+})
+export default class TagSelector extends Vue {
+  get tags() {
+    return ['hoge', 'fuga']
+  }
+}
+</script>

--- a/components/works/WorksFilter.vue
+++ b/components/works/WorksFilter.vue
@@ -48,6 +48,7 @@
       <font-awesome-icon
         class="w-7 cursor-pointer mx-2"
         :icon="['fas', 'plus-circle']"
+        @click="openTagSelector"
       />
     </div>
   </div>
@@ -57,6 +58,8 @@
 import { Component, Vue, Prop } from 'nuxt-property-decorator'
 import BaseTag from '@/components/commons/BaseTag.vue'
 import { Community } from '@/types'
+import { modalStore } from '~/store'
+import TagSelector from './TagSelector.vue'
 
 @Component({
   components: {
@@ -95,6 +98,10 @@ export default class WorksFilter extends Vue {
         `${this.$route.fullPath}&c${this.selectCommunityNum}=${index}`
       )
     }
+  }
+
+  openTagSelector() {
+    modalStore.setModalComponent(TagSelector)
   }
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,8 +3,19 @@
     <Header />
     <Nuxt class="mx-auto my-12 max-w-[90rem]" />
     <Footer />
+    <modal />
   </div>
 </template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Modal from '@/components/commons/Modal.vue'
+export default Vue.extend({
+  components: {
+    Modal
+  }
+})
+</script>
 
 <style>
 html {

--- a/store/modal.ts
+++ b/store/modal.ts
@@ -1,0 +1,46 @@
+import {
+  Module,
+  VuexModule,
+  Mutation,
+  Action,
+  config
+} from 'vuex-module-decorators'
+import axios from 'axios'
+import { Component } from 'vue'
+
+config.rawError = true
+axios.defaults.baseURL = process.env.API_URL
+
+@Module({
+  name: 'modal',
+  stateFactory: true,
+  namespaced: true
+})
+export default class Modal extends VuexModule {
+  private modalComponent: Component | null = null
+
+  public get getComponent(): Component | null {
+    return this.modalComponent
+  }
+
+  @Mutation
+  setModalComponent(c: Component) {
+    console.debug('setModalComponent')
+    this.modalComponent = c
+  }
+
+  @Mutation
+  deleteModalComponent() {
+    this.modalComponent = null
+  }
+
+  @Action
+  public open(c: Component) {
+    this.setModalComponent(c)
+  }
+
+  @Action
+  public close() {
+    this.deleteModalComponent()
+  }
+}

--- a/store/tag.ts
+++ b/store/tag.ts
@@ -1,0 +1,48 @@
+import {
+  Module,
+  VuexModule,
+  Mutation,
+  Action,
+  config
+} from 'vuex-module-decorators'
+import axios from 'axios'
+import { GetTag, Tag } from '~/types'
+
+config.rawError = true
+axios.defaults.baseURL = process.env.API_URL
+
+/**
+ * タグの情報を取得・保持するStore
+ */
+@Module({
+  name: 'tag',
+  stateFactory: true,
+  namespaced: true
+})
+export default class TagStore extends VuexModule {
+  private tags: Tag[] = []
+
+  public get getTags() {
+    return this.tags
+  }
+
+  @Mutation
+  SET_TAGS(tags: Tag[]) {
+    this.tags = tags
+  }
+
+  @Mutation
+  ADD_TAGS(tags: Tag[]) {
+    this.tags.push(...tags)
+  }
+
+  @Action
+  public async fetchTags() {
+    // すべてのタグを取得する
+    const res = await axios.get<GetTag[]>('/tags')
+    if (res.status !== 200) {
+      return
+    }
+    this.SET_TAGS(res.data)
+  }
+}

--- a/store/work_filter.ts
+++ b/store/work_filter.ts
@@ -1,0 +1,59 @@
+import {
+  Module,
+  VuexModule,
+  Mutation,
+  Action,
+  config
+} from 'vuex-module-decorators'
+import axios from 'axios'
+import { GetTag } from '~/types'
+import { tagStore } from '.'
+
+config.rawError = true
+axios.defaults.baseURL = process.env.API_URL
+
+/**
+ * 作品フィルターの条件を保持するStore
+ */
+@Module({
+  name: 'work_filter',
+  stateFactory: true,
+  namespaced: true
+})
+export default class WorkFilter extends VuexModule {
+  private filterTagIds: string[] = []
+
+  public get getFilterTags() {
+    return tagStore.getTags.filter((t) => this.filterTagIds.includes(t.id))
+  }
+
+  @Mutation
+  SET_FILTER_TAGS(tags: GetTag[]) {
+    this.filterTagIds = tags.map((t) => t.id)
+  }
+
+  @Mutation
+  ADD_FILTER_TAGS(id: string) {
+    this.filterTagIds.push(id)
+  }
+
+  @Mutation
+  DELETE_FILTER_TAGS(id: string) {
+    this.filterTagIds = this.filterTagIds.filter((i) => i !== id)
+  }
+
+  @Action
+  public setFilterTags(tags: GetTag[]) {
+    this.SET_FILTER_TAGS(tags)
+  }
+
+  @Action
+  public addFilterTag(tag: GetTag) {
+    this.ADD_FILTER_TAGS(tag.id)
+  }
+
+  @Action
+  public deleteFilterTag(tag: GetTag) {
+    this.DELETE_FILTER_TAGS(tag.id)
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,12 +37,14 @@ export type DeleteStatus = {
   status: string
 }
 
-export type GetTag = {
+export type Tag = {
   name: string
   color: string
   id: string
   community: Community
 }
+
+export type GetTag = Tag
 
 export type HTTPValidationError = {
   detail: ValidationError[]

--- a/utils/store-accessor.ts
+++ b/utils/store-accessor.ts
@@ -2,13 +2,16 @@ import { Store } from 'vuex'
 import { getModule } from 'vuex-module-decorators'
 import Auth from '@/store/auth'
 import Comment from '@/store/comment'
+import Modal from '@/store/modal'
 
 let authStore: Auth
 let commentStore: Comment
+let modalStore: Modal
 
 function initializeStores(store: Store<any>): void {
   authStore = getModule(Auth, store)
   commentStore = getModule(Comment, store)
+  modalStore = getModule(Modal, store)
 }
 
-export { initializeStores, authStore, commentStore }
+export { initializeStores, authStore, commentStore, modalStore }

--- a/utils/store-accessor.ts
+++ b/utils/store-accessor.ts
@@ -3,15 +3,28 @@ import { getModule } from 'vuex-module-decorators'
 import Auth from '@/store/auth'
 import Comment from '@/store/comment'
 import Modal from '@/store/modal'
+import Tag from '@/store/tag'
+import WorkFilter from '~/store/work_filter'
 
 let authStore: Auth
 let commentStore: Comment
 let modalStore: Modal
+let tagStore: Tag
+let workFilterStore: WorkFilter
 
 function initializeStores(store: Store<any>): void {
   authStore = getModule(Auth, store)
   commentStore = getModule(Comment, store)
   modalStore = getModule(Modal, store)
+  tagStore = getModule(Tag, store)
+  workFilterStore = getModule(WorkFilter, store)
 }
 
-export { initializeStores, authStore, commentStore, modalStore }
+export {
+  initializeStores,
+  authStore,
+  commentStore,
+  modalStore,
+  tagStore,
+  workFilterStore
+}


### PR DESCRIPTION
# 行った変更
トップページで利用するタグ選択モーダルを追加した。

#### モーダルの実装
- アプリケーション全体のモーダルを管理する`modalStore`を作成した。
- 今後モーダルを実装する際に利用できるように作成した。

#### タグ取得の実装
- `tagStore`を作成し、APIを叩いて全タグを取得、格納した。
- タグ取得APIを叩くのは`TagSelector.vue`の`created`である。
  - どこかのタイミングで諸々のGETを行う`init`メソッドを整備する or GETのキャッシュを行うよう変更する必要がある。

#### タグ選択の実装
- `workFilterStore`（Workの絞り込みに利用する条件を保持するStore）を作成した。
- 今後コミュニティの条件などもこのStoreに保持する見込みで作成した。

# なぜやった？
タグ選択モーダルが必要なため。

# 関連するissue、ドキュメント
closes #22 