### PR TITLE
ユーザーページのaxiosの処理を実装

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -21,13 +21,15 @@
       class="flex justify-start items-center absolute right-10 top-0 bottom-0"
     >
       <!-- not logged in  -->
-      <base-button
-        v-if="nowLogin && $route.path !== '/works/create'"
-        class="mx-5"
-        title="投稿"
-        @click="$router.push('/works/create')"
-      />
-      <base-button class="mx-5" title="ログイン" @click="clickLogin" />
+      <div v-if="$route.path !== '/works/create'">
+        <base-button
+          v-if="nowLogin"
+          class="mx-5"
+          title="投稿"
+          @click="$router.push('/works/create')"
+        />
+        <base-button v-else class="mx-5" title="ログイン" @click="clickLogin" />
+      </div>
       <!-- logged in -->
       <button class="hover:opacity-60 transition" @click="activeNav = true">
         <img
@@ -139,11 +141,11 @@ export default class Header extends Vue {
   menuItems: string[] = ['下書き', 'マイページ']
 
   get nowLogin() {
-    return false
+    return authStore.nowLogin
   }
 
   get getIcon() {
-    return authStore.getUser.avatarUrl
+    return authStore.getUser.avatar_url
   }
 
   get getName() {

--- a/components/users/UsersProfile.vue
+++ b/components/users/UsersProfile.vue
@@ -38,6 +38,7 @@
     </div>
     <div class="flex justify-around w-full my-5">
       <a
+        v-if="user.github_id !== null"
         :href="'https://github.com/' + user.github_id"
         target="_blank"
         title="GitHub"
@@ -48,6 +49,7 @@
         />
       </a>
       <a
+        v-if="user.twitter_id !== null"
         :href="'https://twitter.com/' + user.twitter_id"
         target="_blank"
         title="Twitter"

--- a/components/users/UsersProfile.vue
+++ b/components/users/UsersProfile.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    v-if="user !== undefined"
     class="
       w-3/4
       flex flex-col
@@ -13,16 +14,16 @@
       mb-12
     "
   >
-    <user-rounded-icon :imageSrc="users.image" isLarge class="m-5" />
+    <user-rounded-icon :imageSrc="user.avatar_url" isLarge class="m-5" />
     <div class="text-4xl m-5">
-      {{ users.name }}
+      {{ user.display_name }}
     </div>
     <div class="text-2xl m-5">
-      {{ users.description }}
+      {{ user.profile }}
     </div>
     <div v-show="!disabledEditButton" class="m-5">
       <base-button title="プロフィール編集" @click="showEditProfile = true" />
-      <users-profile-form v-show="showEditProfile" :users="users">
+      <users-profile-form v-show="showEditProfile" :user="user">
         <base-button
           class="px-7"
           title="変更"
@@ -37,7 +38,7 @@
     </div>
     <div class="flex justify-around w-full my-5">
       <a
-        :href="'https://github.com/' + users.github"
+        :href="'https://github.com/' + user.github_id"
         target="_blank"
         title="GitHub"
       >
@@ -47,7 +48,7 @@
         />
       </a>
       <a
-        :href="'https://twitter.com/' + users.twitter"
+        :href="'https://twitter.com/' + user.twitter_id"
         target="_blank"
         title="Twitter"
       >
@@ -65,14 +66,7 @@ import { Component, Vue, Prop } from 'nuxt-property-decorator'
 import BaseButton from '@/components/commons/BaseButton.vue'
 import UsersProfileForm from '@/components/users/UsersProfileForm.vue'
 import UserRoundedIcon from '@/components/commons/UserRoundedIcon.vue'
-
-interface User {
-  image: string
-  name: string
-  description: string
-  github: string
-  twitter: string
-}
+import { User } from '~/types'
 
 @Component({
   components: {
@@ -83,7 +77,7 @@ interface User {
 })
 export default class UsersProfile extends Vue {
   @Prop({ type: Object, required: true })
-  users!: User
+  user!: User
 
   @Prop({ type: Boolean, required: false, default: false })
   disabledEditButton!: boolean

--- a/components/users/UsersProfile.vue
+++ b/components/users/UsersProfile.vue
@@ -22,23 +22,19 @@
       {{ user.profile }}
     </div>
     <div v-show="!disabledEditButton" class="m-5">
-      <base-button title="プロフィール編集" @click="showEditProfile = true" />
-      <users-profile-form v-show="showEditProfile" :user="user">
-        <base-button
-          class="px-7"
-          title="変更"
-          @click="showEditProfile = false"
-        />
-        <base-button
-          class="px-7"
-          title="やめる"
-          @click="showEditProfile = false"
-        />
-      </users-profile-form>
+      <base-button
+        title="プロフィール編集"
+        @click="showEditProfileModal = true"
+      />
+      <users-profile-form
+        v-show="showEditProfileModal"
+        :user="user"
+        @close-edit-profile-modal="showEditProfileModal = false"
+      />
     </div>
     <div class="flex justify-around w-full my-5">
       <a
-        v-if="user.github_id !== null"
+        v-if="user.github_id !== ''"
         :href="'https://github.com/' + user.github_id"
         target="_blank"
         title="GitHub"
@@ -49,7 +45,7 @@
         />
       </a>
       <a
-        v-if="user.twitter_id !== null"
+        v-if="user.twitter_id !== ''"
         :href="'https://twitter.com/' + user.twitter_id"
         target="_blank"
         title="Twitter"
@@ -84,6 +80,6 @@ export default class UsersProfile extends Vue {
   @Prop({ type: Boolean, required: false, default: false })
   disabledEditButton!: boolean
 
-  showEditProfile: boolean = false
+  showEditProfileModal: boolean = false
 }
 </script>

--- a/components/users/UsersProfileForm.vue
+++ b/components/users/UsersProfileForm.vue
@@ -13,32 +13,37 @@
   >
     <div class="w-1/2 flex flex-col bg-white rounded-md p-10">
       <users-text-field
-        v-model="user.display_name"
+        v-model="displayName"
         label="名前"
         placeholder="名前を入力してください"
       />
       <users-text-field
-        v-model="user.profile"
+        v-model="profile"
         label="自己紹介"
         placeholder="自己紹介をしましょう"
         :textarea="true"
       />
       <users-text-field
-        v-model="user.github_id"
+        v-model="githubId"
         label="GitHub"
         placeholder="GitHub の ID"
       >
         <div class="mr-1 text-gray-500">https://github.com/</div>
       </users-text-field>
       <users-text-field
-        v-model="user.twitter_id"
+        v-model="twitterId"
         label="Twitter"
         placeholder="Twitter の ID"
       >
         <div class="mr-1 text-gray-500">https://twitter.com/</div>
       </users-text-field>
       <div class="mt-5 flex justify-around">
-        <slot />
+        <base-button class="px-7" title="変更" @click="putUserInfo" />
+        <base-button
+          class="px-7"
+          title="やめる"
+          @click="closeEditProfileModal"
+        />
       </div>
     </div>
   </div>
@@ -46,16 +51,69 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import axios from 'axios'
+import BaseButton from '@/components/commons/BaseButton.vue'
 import UsersTextField from '@/components/users/UsersTextField.vue'
 import { User } from '~/types'
+import { authStore } from '~/store'
 
 @Component({
   components: {
+    BaseButton,
     UsersTextField
   }
 })
 export default class UsersProfileForm extends Vue {
   @Prop({ type: Object, required: false, default: [] })
   user!: User
+
+  displayName: string = ''
+  avatarUrl: string = ''
+  profile: string = ''
+  githubId: string = ''
+  twitterId: string = ''
+
+  mounted() {
+    const { display_name, avatar_url, profile, github_id, twitter_id } =
+      this.user
+    this.displayName = display_name
+    this.avatarUrl = avatar_url ?? ''
+    this.profile = profile ?? ''
+    this.githubId = github_id ?? ''
+    this.twitterId = twitter_id ?? ''
+  }
+
+  async putUserInfo() {
+    await axios
+      .put(
+        '/users/@me',
+        {
+          display_name: this.displayName,
+          avatar_url: this.avatarUrl,
+          profile: this.profile,
+          twitter_id: this.twitterId,
+          github_id: this.githubId
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${this.accessToken}`
+          }
+        }
+      )
+      .then((value) => {
+        console.log(value)
+        alert('ユーザー情報を変更しました')
+        this.closeEditProfileModal()
+      })
+      .catch((error) => console.error(error))
+  }
+
+  closeEditProfileModal() {
+    this.$emit('close-edit-profile-modal')
+  }
+
+  get accessToken() {
+    return authStore.getAccessToken
+  }
 }
 </script>

--- a/components/users/UsersProfileForm.vue
+++ b/components/users/UsersProfileForm.vue
@@ -13,25 +13,25 @@
   >
     <div class="w-1/2 flex flex-col bg-white rounded-md p-10">
       <users-text-field
-        v-model="users.name"
+        v-model="user.display_name"
         label="名前"
         placeholder="名前を入力してください"
       />
       <users-text-field
-        v-model="users.description"
+        v-model="user.profile"
         label="自己紹介"
         placeholder="自己紹介をしましょう"
         :textarea="true"
       />
       <users-text-field
-        v-model="users.github"
+        v-model="user.github_id"
         label="GitHub"
         placeholder="GitHub の ID"
       >
         <div class="mr-1 text-gray-500">https://github.com/</div>
       </users-text-field>
       <users-text-field
-        v-model="users.twitter"
+        v-model="user.twitter_id"
         label="Twitter"
         placeholder="Twitter の ID"
       >
@@ -47,14 +47,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from 'nuxt-property-decorator'
 import UsersTextField from '@/components/users/UsersTextField.vue'
-
-interface User {
-  image: string
-  name: string
-  description: string
-  github: string
-  twitter: string
-}
+import { User } from '~/types'
 
 @Component({
   components: {
@@ -63,6 +56,6 @@ interface User {
 })
 export default class UsersProfileForm extends Vue {
   @Prop({ type: Object, required: false, default: [] })
-  users!: User
+  user!: User
 }
 </script>

--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <users-profile :users="users" />
+    <users-profile :user="fetchUser" />
     <works-filter :communities="communities" />
     <works-list :works="works" />
   </div>
@@ -13,14 +13,7 @@ import UsersProfile from '@/components/users/UsersProfile.vue'
 import WorksFilter from '@/components/works/WorksFilter.vue'
 import WorksList from '@/components/works/WorksList.vue'
 import { Work } from '@/types'
-
-interface User {
-  image: string
-  name: string
-  description: string
-  github: string
-  twitter: string
-}
+import { authStore } from '~/store'
 
 @Component({
   components: {
@@ -48,13 +41,9 @@ export default class Users extends Vue {
   works!: Work[]
   userWorksCount: number = 6
   userWorks: string[] = Array(this.userWorksCount)
-  users: User = {
-    image:
-      'http://3.bp.blogspot.com/-n0PpkJL1BxE/VCIitXhWwpI/AAAAAAAAmfE/xLraJLXXrgk/s800/animal_hamster.png',
-    name: 'ハムタロサァン',
-    description: 'はむたろなのだ',
-    github: 'Kyutech-C3',
-    twitter: 'c3_kyutech'
+
+  get fetchUser() {
+    return authStore.getUser
   }
 }
 </script>

--- a/store/auth.ts
+++ b/store/auth.ts
@@ -6,20 +6,10 @@ import {
   config
 } from 'vuex-module-decorators'
 import axios from 'axios'
+import { User } from '~/types'
 
 config.rawError = true
 axios.defaults.baseURL = process.env.API_URL
-
-type User = {
-  id: string
-  name: string
-  email: string
-  displayName: string
-  discordToken: string
-  discordRefreshToken: string
-  discordUserId: string
-  avatarUrl: string
-}
 
 @Module({
   name: 'auth',
@@ -31,11 +21,9 @@ export default class Auth extends VuexModule {
     id: '',
     name: '',
     email: '',
-    displayName: '',
-    discordToken: '',
-    discordRefreshToken: '',
-    discordUserId: '',
-    avatarUrl: ''
+    display_name: '',
+    created_at: '',
+    updated_at: ''
   }
 
   private accessToken: string = ''
@@ -53,15 +41,8 @@ export default class Auth extends VuexModule {
   }
 
   @Mutation
-  setUser(user: any) {
-    this.user.id = user.id
-    this.user.name = user.name
-    this.user.email = user.email
-    this.user.displayName = user.display_name
-    this.user.discordToken = user.discord_token
-    this.user.discordRefreshToken = user.discord_refresh_token
-    this.user.discordUserId = user.discord_user_id
-    this.user.avatarUrl = user.avatar_url
+  setUser(user: User) {
+    this.user = user
   }
 
   @Mutation


### PR DESCRIPTION
# 行った変更

#### ログイン処理の修正

- ログインしても表示上何も変化がなかったため、動くように修正
- Users型を`types/index.d.ts`を使用したものにリファクタリング

#### ユーザーページのGET処理を実装

- storeにユーザー情報が入っているので、それを参照して表示

####  github_idとtwitter_idがnullの場合にボタンを非表示

- idが`null`だと`https://twitter.com/null`になるので非表示にした

#### プロフィール編集のPUT処理を実装
  - プロフィール編集から変更ボタンを押すとaxiosで`/users/@me`にPUTする

## 問題点

- プロフィールを編集した際に、編集内容が即座に表示上で反映されない
  - ページを更新すると反映される

## 解決策

- PUTに成功した場合はユーザー情報をGETしてstoreのuserを上書きする