### PR TITLE
ブログ一覧から自分のブログ記事を削除する機能を実装

### DIFF
--- a/components/blogs/BlogCard.vue
+++ b/components/blogs/BlogCard.vue
@@ -124,6 +124,7 @@ import UserTag from '@/components/commons/UserTag.vue'
 import BaseIconButton from '@/components/commons/BaseIconButton.vue'
 import VisibilityStateTag from '@/components/commons/VisibilityStateTag.vue'
 
+import { AxiosClient } from '@/utils/axios'
 import { Blog } from '@/types'
 import { authStore } from '~/store'
 
@@ -163,8 +164,25 @@ export default class BlogCard extends Vue {
   deleteBlog() {
     const msg = `「${this.blogData.title}」\nこの記事を削除してもよろしいですか？`
     if (confirm(msg)) {
-      // TODO: ここでブログ削除APIを叩く
-      console.log(`delete ${this.blogData.id}`)
+      try {
+        if (this.getNowLogin) {
+          AxiosClient.client(
+            'DELETE',
+            `${process.env.API_URL}/blogs/${this.blogData.id}`,
+            true
+          )
+            .then(() => {
+              this.$router.go(0)
+            })
+            .catch((error) => {
+              console.error(error)
+              alert('削除できませんでした>_<管理者に報告してください！')
+            })
+        }
+      } catch (error) {
+        console.error(error)
+        alert('削除できませんでした>_<管理者に報告してください！')
+      }
     }
   }
 


### PR DESCRIPTION
ブログの削除機能が未実装だったので、以下に示す作品(Toy)の削除機能を参考に実装しました。
https://github.com/Kyutech-C3/ToyBox-frontend/blob/a695a6addcd813b0041fd5aae5db2504002a519e/pages/works/_id/index.vue#L715-L738

上記の作品削除機能からの実質的な相違点として、恐らく未使用と思われる`deleteStatus`プロパティを削除し、削除が成功したらトップページに戻るのではなくそのとき開いていたページをリロードするようにしています。  
特にページ遷移の扱いはどうせならいずれかに統一すべきですが、一旦今回の実装が問題無いかだけでも意見がほしいです。